### PR TITLE
Fix logback file location.

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -29,6 +29,11 @@
             <version>${fileapi.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>2.7.8</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/application/src/main/resources/logback.xml
+++ b/application/src/main/resources/logback.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <if condition='isDefined("catalina.home")'>
+        <then>
+            <property name="log.location" value="${catalina.home}/logs"/>
+        </then>
+        <else>
+            <property name="log.location" value="./target/logs"/>
+        </else>
+    </if>
+
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <Pattern>.%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %n </Pattern>
@@ -10,10 +19,10 @@
     </appender>
 
     <appender name="fileAppender" class="ch.qos.logback.core.FileAppender">
-        <file>${catalina.base}/logs/log-music-for-all.txt</file>
+        <file>${log.location}/music-for-all.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- daily rollover -->
-            <fileNamePattern>${catalina.base}/logs/log-music-for-all.txt.%d.gz</fileNamePattern>
+            <fileNamePattern>${log.location}/music-for-all.log.%d.gz</fileNamePattern>
             <maxHistory>30</maxHistory>
         </rollingPolicy>
         <encoder>


### PR DESCRIPTION
The file location is now depends on whether the application is deployed on Tomcat. If ${catalina_home} is not defined, log files are stored in the directory target/logs of the module 'application'.